### PR TITLE
fixed motor.ramp_speed as it resulted in Exception [draft]

### DIFF
--- a/bricknil/sensor/motor.py
+++ b/bricknil/sensor/motor.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """All motor related peripherals including base motor classes"""
 
-from asyncio import sleep, current_task, create_task as spawn  # Needed for motor speed ramp
+from asyncio import sleep, current_task, create_task
 
 from enum import Enum
 from struct import pack
@@ -94,7 +94,7 @@ class Motor(Peripheral):
             self.ramp_in_progress_task = None
 
         self.message_debug(f'Starting ramp of speed: {start_speed} -> {target_speed} ({ramp_time_ms/1000}s)')
-        self.ramp_in_progress_task = await spawn(_ramp_speed, daemon = True)
+        self.ramp_in_progress_task = await create_task(_ramp_speed())
 
 class TachoMotor(Motor):
 

--- a/bricknil/sensor/motor.py
+++ b/bricknil/sensor/motor.py
@@ -40,16 +40,14 @@ class Motor(Peripheral):
                     Use 0 to put the motor into neutral.
                     255 will do a hard brake - according to "peripherial.py _convert_speed_to_val" ist should be "127" (?)
         """
-        await self._cancel_existing_differet_ramp()
+        await self._cancel_existing_different_ramp()
         self.speed = speed
         self.message_info(f'Setting speed to {speed}')
         await self.set_output(0, self._convert_speed_to_val(speed))
 
-    async def _cancel_existing_differet_ramp(self):
+    async def _cancel_existing_different_ramp(self):
         """Cancel the existing speed ramp if it was from a different task
 
-            Remember that speed ramps must be a task with daemon=True, so there is no
-            one awaiting its future.
         """
         # Check if there's a ramp task in progress
         if self.ramp_in_progress_task:
@@ -68,7 +66,7 @@ class Motor(Peripheral):
 
         """
         TIME_STEP_MS = 100
-        await self._cancel_existing_differet_ramp()
+        await self._cancel_existing_different_ramp()
         assert ramp_time_ms > 100, f'Ramp speed time must be greater than 100ms ({ramp_time_ms}ms used)'
 
         # 500ms ramp time, 100ms per step


### PR DESCRIPTION
motor.ramp_speed currently results in the following exception, as it probably still relied on the curio API for `spawn()`:
```
Exception has occurred: TypeError
create_task() got an unexpected keyword argument 'daemon'
  File "E:\repos\bricknil\bricknil\sensor\motor.py", line 97, in ramp_speed
    self.ramp_in_progress_task = await spawn(_ramp_speed, daemon = True)
  File "E:\repos\auto-rail\tests\test_github_issue.py", line 26, in program_train
    await train.motor.ramp_speed(50, 3000)
  File "E:\repos\bricknil\bricknil\bricknil.py", line 149, in main
    await program
  File "E:\repos\bricknil\bricknil\bricknil.py", line 153, in run
    loop.run_until_complete(main())
  File "E:\repos\auto-rail\tests\test_github_issue.py", line 37, in <module>
    bricknil.run(program_train())
```
I just made a tiny modification so it should work again.

Please don't merge this yet, as this makes the program wait for the ramp to complete, which isn't intended